### PR TITLE
Reject invalid subscribers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "claims"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6995bbe186456c36307f8ea36be3eefe42f49d106896414e18efc4fb2f846b5"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "config"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,6 +2811,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "chrono",
+ "claims",
  "config",
  "deadpool-postgres",
  "postgres",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +589,16 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fake"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
+dependencies = [
+ "deunicode",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1092,6 +1108,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -2444,7 +2470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.0.3",
  "percent-encoding",
 ]
 
@@ -2468,6 +2494,21 @@ checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
  "getrandom 0.3.1",
  "serde",
+]
+
+[[package]]
+name = "validator"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db79c75af171630a3148bd3e6d7c4f42b6a9a014c2945bc5ed0020cbb8d9478e"
+dependencies = [
+ "idna 0.5.0",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -2814,6 +2855,7 @@ dependencies = [
  "claims",
  "config",
  "deadpool-postgres",
+ "fake",
  "postgres",
  "postgres-types",
  "reqwest",
@@ -2828,6 +2870,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-segmentation",
  "uuid",
+ "validator",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2810,6 +2816,7 @@ dependencies = [
  "tracing-bunyan-formatter",
  "tracing-log 0.2.0",
  "tracing-subscriber",
+ "unicode-segmentation",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ deadpool-postgres = "0.12"
 unicode-segmentation = "1"
 claims = "0.7"
 
+validator = "0.18"
+fake = "2.9"
+
 [dev-dependencies]
 reqwest = "0.12"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio-postgres = "0.7"
 deadpool-postgres = "0.12"
 
 unicode-segmentation = "1"
+claims = "0.7"
 
 [dev-dependencies]
 reqwest = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ postgres = { version = "0.19", features = ["with-uuid-1", "with-chrono-0_4"] }
 tokio-postgres = "0.7"
 deadpool-postgres = "0.12"
 
+unicode-segmentation = "1"
+
 [dev-dependencies]
 reqwest = "0.12"
 

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,0 +1,45 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+pub struct SubscriberName(String);
+
+impl SubscriberName {
+    /// Returns an instance of `SubscriberName` if the input satisfies all
+    /// our validation constraints on subscriber names.
+    /// It panics otherwise.
+    pub fn parse(s: String) -> SubscriberName {
+        // `.trim()` returns a view over the input `s` without trailing
+        // whitespace-like characters.
+        // `.is_empty` checks if the view contains any character.
+        let is_empty_or_whitespace = s.trim().is_empty();
+
+        // A grapheme is defined by the Unicode standard as a "user-perceived"
+        // character: `å` is a single grapheme, but it is composed of two characters
+        // (`a` and `̊`).
+        //
+        // `graphemes` returns an iterator over the graphemes in the input `s`.
+        // `true` specifies that we want to use the extended grapheme definition set,
+        // the recommended one.
+        let is_too_long = s.graphemes(true).count() > 256;
+
+        // Iterate over all characters in the input `s` to check if any of them
+        // matches one of the characters in the forbidden array.
+        let forbidden_characters = ['/', '(', ')', '"', '<', '>', '\\', '{', '}'];
+        let contains_forbidden_characters = s.chars().any(|g| forbidden_characters.contains(&g));
+        if is_empty_or_whitespace || is_too_long || contains_forbidden_characters {
+            panic!("{} is not a valid subscriber name.", s)
+        } else {
+            Self(s)
+        }
+    }
+}
+
+impl AsRef<str> for SubscriberName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+pub struct NewSubscriber {
+    pub email: String,
+    pub name: SubscriberName,
+}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,12 +1,13 @@
 use unicode_segmentation::UnicodeSegmentation;
 
+#[derive(Debug)]
 pub struct SubscriberName(String);
 
 impl SubscriberName {
     /// Returns an instance of `SubscriberName` if the input satisfies all
     /// our validation constraints on subscriber names.
     /// It panics otherwise.
-    pub fn parse(s: String) -> SubscriberName {
+    pub fn parse(s: String) -> Result<SubscriberName, String> {
         // `.trim()` returns a view over the input `s` without trailing
         // whitespace-like characters.
         // `.is_empty` checks if the view contains any character.
@@ -26,9 +27,9 @@ impl SubscriberName {
         let forbidden_characters = ['/', '(', ')', '"', '<', '>', '\\', '{', '}'];
         let contains_forbidden_characters = s.chars().any(|g| forbidden_characters.contains(&g));
         if is_empty_or_whitespace || is_too_long || contains_forbidden_characters {
-            panic!("{} is not a valid subscriber name.", s)
+            Err(format!("{} is not a valid subscriber name.", s))
         } else {
-            Self(s)
+            Ok(Self(s))
         }
     }
 }
@@ -42,4 +43,48 @@ impl AsRef<str> for SubscriberName {
 pub struct NewSubscriber {
     pub email: String,
     pub name: SubscriberName,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::SubscriberName;
+    use claims::{assert_err, assert_ok};
+
+    #[test]
+    fn a_256_grapheme_long_name_is_valid() {
+        let name = "é".repeat(256);
+        assert_ok!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn a_name_longer_than_256_graphemes_is_rejected() {
+        let name = "a".repeat(257);
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn whitespace_only_names_are_rejected() {
+        let name = " ".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn empty_string_is_rejected() {
+        let name = "".to_string();
+        assert_err!(SubscriberName::parse(name));
+    }
+
+    #[test]
+    fn names_containing_an_invalid_character_are_rejected() {
+        for name in &['/', '(', ')', '"', '<', '>', '\\', '{', '}'] {
+            let name = name.to_string();
+            assert_err!(SubscriberName::parse(name));
+        }
+    }
+
+    #[test]
+    fn a_valid_name_is_parsed_successfully() {
+        let name = "Ursula Le Guin".to_string();
+        assert_ok!(SubscriberName::parse(name));
+    }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,7 @@
+mod new_subscriber;
+mod subscriber_email;
+mod subscriber_name;
+
+pub use new_subscriber::NewSubscriber;
+pub use subscriber_email::SubscriberEmail;
+pub use subscriber_name::SubscriberName;

--- a/src/domain/new_subscriber.rs
+++ b/src/domain/new_subscriber.rs
@@ -1,0 +1,8 @@
+use crate::domain::SubscriberName;
+
+use super::SubscriberEmail;
+
+pub struct NewSubscriber {
+    pub email: SubscriberEmail,
+    pub name: SubscriberName,
+}

--- a/src/domain/subscriber_email.rs
+++ b/src/domain/subscriber_email.rs
@@ -1,0 +1,52 @@
+use validator::ValidateEmail;
+
+#[derive(Debug)]
+pub struct SubscriberEmail(String);
+
+impl SubscriberEmail {
+    pub fn parse(s: String) -> Result<SubscriberEmail, String> {
+        if s.validate_email() {
+            Ok(Self(s))
+        } else {
+            Err(format!("{} is not a valid subscriber email", s))
+        }
+    }
+}
+
+impl AsRef<str> for SubscriberEmail {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SubscriberEmail;
+    use claims::assert_err;
+    use fake::faker::internet::en::SafeEmail;
+    use fake::Fake;
+
+    #[test]
+    fn empty_email_is_rejected() {
+        let email = "".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_at_symbol_is_rejected() {
+        let email = "ursuladomain.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn email_missing_subject_is_rejected() {
+        let email = "@domain.com".to_string();
+        assert_err!(SubscriberEmail::parse(email));
+    }
+
+    #[test]
+    fn valid_emails_are_parsed_successfully() {
+        let email = SafeEmail().fake();
+        claims::assert_ok!(SubscriberEmail::parse(email));
+    }
+}

--- a/src/domain/subscriber_name.rs
+++ b/src/domain/subscriber_name.rs
@@ -40,11 +40,6 @@ impl AsRef<str> for SubscriberName {
     }
 }
 
-pub struct NewSubscriber {
-    pub email: String,
-    pub name: SubscriberName,
-}
-
 #[cfg(test)]
 mod tests {
     use crate::domain::SubscriberName;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod configuration;
 pub mod routes;
 pub mod startup;
 pub mod telemetry;
+pub mod domain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod configuration;
+pub mod domain;
 pub mod routes;
 pub mod startup;
 pub mod telemetry;
-pub mod domain;

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -24,7 +24,7 @@ pub async fn subscribe(form: web::Form<FormData>, pool: web::Data<Pool>) -> Http
     // `form.0` gives us access to the underlying Formdata
     let new_subscriber = NewSubscriber {
         email: form.0.email,
-        name: SubscriberName::parse(form.0.name),
+        name: SubscriberName::parse(form.0.name).expect("Name validation failed"),
     };
 
     match insert_subscriber(&pool, &new_subscriber).await {

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -81,3 +81,34 @@ async fn subscribe_returns_a_400_when_data_is_missing() {
         );
     }
 }
+
+#[tokio::test]
+async fn subscribe_returns_200_when_fields_are_present_but_empty() {
+    // Arrange
+    let app = TestApp::spawn().await;
+    let client = reqwest::Client::new();
+
+    let test_cases = vec![
+        ("name=&email=ursula_le_guin%40gmail.com", "empty name"),
+        ("name=Ursula&email=", "empty email"),
+        ("name=Ursula&email=definitely-not-an-email", "invalid email"),
+    ];
+
+    for (body, description) in test_cases {
+        //act
+        let response = client
+            .post(&format!("{}/subscriptions", &app.address))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body)
+            .send()
+            .await
+            .expect("Failed to execute request");
+        // assert
+        assert_eq!(
+            200,
+            response.status().as_u16(),
+            "The API did not return a 200 OK when the payload was {}.",
+            description
+        )
+    }
+}

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -83,7 +83,7 @@ async fn subscribe_returns_a_400_when_data_is_missing() {
 }
 
 #[tokio::test]
-async fn subscribe_returns_200_when_fields_are_present_but_empty() {
+async fn subscribe_returns_400_when_fields_are_present_but_empty() {
     // Arrange
     let app = TestApp::spawn().await;
     let client = reqwest::Client::new();
@@ -105,9 +105,9 @@ async fn subscribe_returns_200_when_fields_are_present_but_empty() {
             .expect("Failed to execute request");
         // assert
         assert_eq!(
-            200,
+            400,
             response.status().as_u16(),
-            "The API did not return a 200 OK when the payload was {}.",
+            "The API did not return a 400 OK when the payload was {}.",
             description
         )
     }


### PR DESCRIPTION
Add validation of incoming form data
Add domain module with types for input conversion, parsing, AsRef impl.
Add claims crate for better unit test failure messages
Add fake crate for unit test data
Add TryInto impl for FormData which parses subscriber name, email.
Alter signature of parsing operation to Result<T, String>
Add match on parsing failure Error type (String) to HttpError 